### PR TITLE
Add opt-out possibility for HTTP RPC endpoint and Sys RPC service

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -12,6 +12,8 @@ includes:
 config_schema:
   - ["rpc", "o", {title: "RPC settings"}]
   - ["rpc.enable", "b", true, {title: "Enable RPC"}]
+  - ["rpc.http_enable", "b", true, {title: "Enable RPC over HTTP"}]
+  - ["rpc.service_sys_enable", "b", true, {title: "Enable Sys RPC service"}]
   - ["rpc.max_frame_size", "i", 4096, {title: "Max Frame Size"}]
   - ["rpc.max_queue_length", "i", 25, {title: "Max Queue Length"}]
   - ["rpc.default_out_channel_idle_close_timeout", "i", 10, {title: "Default idle close timeout for outbound channels"}]

--- a/src/mgos_rpc.c
+++ b/src/mgos_rpc.c
@@ -487,7 +487,7 @@ bool mgos_rpc_common_init(void) {
   mg_rpc_set_prehandler(c, mgos_rpc_req_prehandler, NULL);
 
 #if defined(MGOS_HAVE_HTTP_SERVER) && MGOS_ENABLE_RPC_CHANNEL_HTTP
-  {
+  if (mgos_sys_config_get_rpc_http_enable()) {
     struct mg_http_endpoint_opts opts;
     memset(&opts, 0, sizeof(opts));
 
@@ -505,12 +505,14 @@ bool mgos_rpc_common_init(void) {
   }
 
 #if MGOS_ENABLE_SYS_SERVICE
-  mg_rpc_add_handler(c, "Sys.Reboot", "{delay_ms: %d}", mgos_sys_reboot_handler,
-                     NULL);
-  mg_rpc_add_handler(c, "Sys.GetInfo", "", mgos_sys_get_info_handler, NULL);
-  mg_rpc_add_handler(c, "Sys.SetDebug",
-                     "{udp_log_addr: %Q, level: %d, file_level: %Q}",
-                     mgos_sys_set_debug_handler, NULL);
+  if (mgos_sys_config_get_rpc_service_sys_enable()) {
+    mg_rpc_add_handler(c, "Sys.Reboot", "{delay_ms: %d}",
+                       mgos_sys_reboot_handler, NULL);
+    mg_rpc_add_handler(c, "Sys.GetInfo", "", mgos_sys_get_info_handler, NULL);
+    mg_rpc_add_handler(c, "Sys.SetDebug",
+                       "{udp_log_addr: %Q, level: %d, file_level: %Q}",
+                       mgos_sys_set_debug_handler, NULL);
+  }
 #endif
 
   mgos_event_add_group_handler(MGOS_EVENT_GRP_NET, mg_rpc_net_ready, NULL);


### PR DESCRIPTION
I've added configuration options for following usecases:

- i want MQTT RPC and webserver serving files, but i don't want HTTP RPC
- i want RPC, but i don't want `Sys.*` RPC services