### PR TITLE
mg_rpc_check_nonce smaller time drift tolerance

### DIFF
--- a/src/mg_rpc.c
+++ b/src/mg_rpc.c
@@ -915,9 +915,11 @@ bool mg_rpc_send_error_jsonf(struct mg_rpc_request_info *ri, int error_code,
 }
 
 static bool mg_rpc_check_nonce(const char *nonce) {
+  /* expecting time to be in unix seconds */
   double now = mg_time();
   double val = (double) strtoul(nonce, NULL, 10);
-  return (now >= val) && (now - val < 60 * 60);
+  /* expect within 2 minutes */
+  return (abs(now - val) < 60 * 2);
 }
 
 bool mg_rpc_check_digest_auth(struct mg_rpc_request_info *ri) {


### PR DESCRIPTION
I'd suggest that providing an hour in the past is too long. Even with global traversing MQTT and processing delays it should handle a response well within 2 minutes.
NTP docs suggest a device without NTP sync will drift about 8 seconds a day. 2 minutes provides a full week without sync.

I've provided a method that doesn't presume this device is accurate, the client who offered an initial nonce before the challenge may actually have the correct time.